### PR TITLE
Added new Romanian lemma lookup table

### DIFF
--- a/spacy_lookups_data/data/ro_licence.txt
+++ b/spacy_lookups_data/data/ro_licence.txt
@@ -1,0 +1,15 @@
+Copyright © 2004-2020 dexonline (https://dexonline.ro)
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.


### PR DESCRIPTION
Hello, I have added a more comprehensive lemma lookup table for romanian. The dataset is distributed by dexonline.ro under GPLv2+ license as a mysql dump. It can be found here: https://wiki.dexonline.ro/wiki/Instruc%C8%9Biuni_de_instalare
The json file has been generated by importing the dump into mysql and running the following script: https://gist.github.com/CajuM/d08615ac3b9c82dcde6480895824c6e0