### PR TITLE
Use gzip instead of srsly to simplify install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-srsly>=0.1.0,<1.1.0
 pathlib==1.0.1; python_version < "3.4"
 # Test requirements
 spacy>=2.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 install_requires =
     setuptools
 setup_requires =
-    srsly>=0.1.0,<1.1.0
     pathlib==1.0.1; python_version < "3.4"
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def gzip_language_data(root, source):
             # If the gz is newer it doesn't need updating
             print("Skipping {}, already compressed".format(jsonfile))
             continue
-        with open(jsonfile, 'r') as infileh, gzip.open(outfile, 'w') as outfileh:
+        with open(str(jsonfile), 'r') as infileh, gzip.open(str(outfile), 'w') as outfileh:
             outfileh.write(infileh.read().encode("utf-8"))
         print("Compressed {}".format(jsonfile))
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def gzip_language_data(root, source):
             # If the gz is newer it doesn't need updating
             print("Skipping {}, already compressed".format(jsonfile))
             continue
-        with open(str(jsonfile), 'r') as infileh, gzip.open(str(outfile), 'w') as outfileh:
+        with open(str(jsonfile), 'r', encoding="utf-8") as infileh, gzip.open(str(outfile), 'w') as outfileh:
             outfileh.write(infileh.read().encode("utf-8"))
         print("Compressed {}".format(jsonfile))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 def gzip_language_data(root, source):
     print("Compressing language data")
-    import srsly
+    import gzip
     from pathlib import Path
 
     base = Path(root) / source
@@ -18,8 +18,8 @@ def gzip_language_data(root, source):
             # If the gz is newer it doesn't need updating
             print("Skipping {}, already compressed".format(jsonfile))
             continue
-        data = srsly.read_json(jsonfile)
-        srsly.write_gzip_json(outfile, data)
+        with open(jsonfile, 'r') as infileh, gzip.open(outfile, 'w') as outfileh:
+            outfileh.write(infileh.read().encode("utf-8"))
         print("Compressed {}".format(jsonfile))
 
 


### PR DESCRIPTION
Replace srsly with gzip to simplify setup in a clean environment.