### PR TITLE
Update test requirements to spacy>=2.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pathlib==1.0.1; python_version < "3.4"
 # Test requirements
-spacy>=2.2.2
+spacy>=2.3.0
 pytest>=4.1.0


### PR DESCRIPTION
Updating test requirements to `spacy>=2.3.0` so that the CI tests include the normalization lookups.