### PR TITLE
Fix singing lemma

### DIFF
--- a/spacy_lookups_data/data/en_lemma_exc.json
+++ b/spacy_lookups_data/data/en_lemma_exc.json
@@ -5330,7 +5330,6 @@
         "signified": ["signify"],
         "silicified": ["silicify"],
         "simplified": ["simplify"],
-        "singing": ["sing", "singe"],
         "single-stepped": ["single-step"],
         "single-stepping": ["single-step"],
         "sinned": ["sin"],

--- a/spacy_lookups_data/data/en_lemma_lookup.json
+++ b/spacy_lookups_data/data/en_lemma_lookup.json
@@ -33899,7 +33899,7 @@
     "singeing": "singe",
     "singers": "singer",
     "singes": "singe",
-    "singing": "singe",
+    "singing": "sing",
     "singings": "singing",
     "single-deckers": "single-decker",
     "singled": "single",

--- a/spacy_lookups_data/tests/test_en.py
+++ b/spacy_lookups_data/tests/test_en.py
@@ -18,6 +18,13 @@ def test_issue4104(en_lookup_nlp):
     doc = lemmatizer(doc)
     assert [token.lemma_ for token in doc] == ["dry", "spin", "spin-dry"]
 
+def test_issue7306(en_lookup_nlp):
+    """Test that English lookup lemmatization of singing is sing."""
+    doc = Doc(en_lookup_nlp.vocab, words=["singing"])
+    lemmatizer = en_lookup_nlp.get_pipe("lemmatizer")
+    doc = lemmatizer(doc)
+    assert doc[0].lemma_ == "sing"
+
 
 @pytest.mark.parametrize(
     "text,norms", [("I'm", ["i", "am"]), ("shan't", ["shall", "not"])]


### PR DESCRIPTION
See this issue:

https://github.com/explosion/spaCy/issues/7306

I did have to look this up to confirm, but it seems like the -ing form of "singe" should always be "singeing", never "singing". In contrast, the data here currently always gives the lemma of "singing" as "singe". 

Example dictionary entry:

https://www.merriam-webster.com/dictionary/singe